### PR TITLE
release: Version 2.92 (Eggies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Version 2.5 introduces the ability to export and import your save data. This is 
 ## **Changelog**
 
 ### **Version 2.92 (Eggies)**
-*   **Feature (UI):** Added a new banner to display all active colored egg buffs, showing their name and remaining duration.
+*   **Feature (UI):** Added a new banner at the top of the screen that displays all active colored egg buffs. Each buff is shown as a colored "pill" with its name, an icon, and a countdown of its remaining duration in seconds.
 *   **Housekeeping:** Updated version number to 2.92.
 
 ### **Version 2.91 (Jules)**
-*   **Critical Fix (Reputation):** Fixed a major bug where Reputation gain would stall. The calculation for prestige has been corrected to properly include contributions from Roosters and the Wyandotte Warrior's bonus (which has also been increased).
-*   **Critical Fix (Buffs):** Fixed a bug that caused the Red Egg's "clickFrenzy" buff and other temporary buffs to not apply correctly or expire. The entire buff-handling system is now more robust.
-*   **Feature (UI):** Added progress bars and percentage text to achievements in the achievements panel, allowing players to see how close they are to unlocking them.
+*   **Critical Fix (Reputation):** Overhauled the reputation calculation for prestige. Roosters now grant a base of 1,000 Reputation each. The bonus from Wyandotte Warriors has been increased from 1% to 5% per chicken. This resolves the issue of reputation gain stalling at high levels.
+*   **Critical Fix (Buffs):** Rewrote the buff expiration logic in the main game loop to correctly decrement and remove temporary buffs. This fixes a critical bug where buffs like the Red Egg's "clickFrenzy" would not apply or expire correctly.
+*   **Feature (UI):** Added progress bars to all non-hidden achievements that track a specific number (e.g., total clicks, eggs, buildings owned). The bar shows the current progress and a "current / target" number count.
 *   **Housekeeping:** Updated version number to 2.91.
 
 ### **Version 2.9 (Cluck You Totoro!)**

--- a/index.html
+++ b/index.html
@@ -198,14 +198,14 @@
                         <div class="mt-2 space-y-2 text-xs">
                             <h4>Version 2.92 (Eggies)</h4>
                             <ul class="list-disc pl-5">
-                                <li><strong>Feature (UI):</strong> Added a new banner to display all active colored egg buffs, showing their name and remaining duration.</li>
+                                <li><strong>Feature (UI):</strong> Added a new banner at the top of the screen that displays all active colored egg buffs. Each buff is shown as a colored "pill" with its name, an icon, and a countdown of its remaining duration in seconds.</li>
                                 <li><strong>Housekeeping:</strong> Updated version number to 2.92.</li>
                             </ul>
                             <h4>Version 2.91 (Jules)</h4>
                             <ul class="list-disc pl-5">
-                                <li><strong>Critical Fix (Reputation):</strong> Fixed a major bug where Reputation gain would stall. The calculation for prestige has been corrected to properly include contributions from Roosters and the Wyandotte Warrior's bonus (which has also been increased).</li>
-                                <li><strong>Critical Fix (Buffs):</strong> Fixed a bug that caused the Red Egg's "clickFrenzy" buff and other temporary buffs to not apply correctly or expire. The entire buff-handling system is now more robust.</li>
-                                <li><strong>Feature (UI):</strong> Added progress bars and percentage text to achievements in the achievements panel, allowing players to see how close they are to unlocking them.</li>
+                                <li><strong>Critical Fix (Reputation):</strong> Overhauled the reputation calculation for prestige. Roosters now grant a base of 1,000 Reputation each. The bonus from Wyandotte Warriors has been increased from 1% to 5% per chicken. This resolves the issue of reputation gain stalling at high levels.</li>
+                                <li><strong>Critical Fix (Buffs):</strong> Rewrote the buff expiration logic in the main game loop to correctly decrement and remove temporary buffs. This fixes a critical bug where buffs like the Red Egg's "clickFrenzy" would not apply or expire correctly.</li>
+                                <li><strong>Feature (UI):</strong> Added progress bars to all non-hidden achievements that track a specific number (e.g., total clicks, eggs, buildings owned). The bar shows the current progress and a "current / target" number count.</li>
                                 <li><strong>Housekeeping:</strong> Updated version number to 2.91.</li>
                             </ul>
 						    <h4>Version 2.9 (Cluck You Totoro!)</h4>


### PR DESCRIPTION
This release bundles several major updates, including critical bug fixes, new UI features, and comprehensive documentation updates.

Features:
- Adds a new UI banner to display all active colored egg buffs, showing their name and remaining duration.
- Adds progress bars to achievements to show completion percentage.

Bug Fixes:
- Corrects the reputation calculation on prestige to include contributions from Roosters and an increased Wyandotte Warrior bonus.
- Fixes the buff system to ensure temporary buffs like the Red Egg's 'clickFrenzy' apply and expire correctly.

Docs:
- Updates the game version to 2.92 (Eggies).
- Updates both the README.md and the in-app changelog with verbose details for versions 2.91 and 2.92.