### PR TITLE
refactor(ui): Relocate the egg effects banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     
         <div id="game-container" class="flex flex-col h-full relative">
             <div id="event-banner" class="funky-font text-xl md:text-2xl"></div>
-            <div id="egg-effects-banner" class="egg-effects-banner"></div>
             <div id="colored-egg-container" class="absolute inset-0"></div>
 
             <header class="text-center pt-6 pb-2">
@@ -49,6 +48,8 @@
                     </svg>
                 </div>
             </main>
+
+            <div id="egg-effects-banner" class="egg-effects-banner"></div>
         </div>
 
         <nav class="bottom-nav md:absolute">


### PR DESCRIPTION
Moves the `egg-effects-banner` div from the top of the screen to the bottom of the main game container. This places it below the main chicken graphic and above the bottom navigation bar, which is a less crowded and more intuitive location for the feature.

This change is purely a layout adjustment and has no impact on game logic.