### PR TITLE
docs: Update "How to Play" section for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,10 @@
 				
 				<h3>Key Concepts & Mechanics</h3>
 				<p><strong>Upgrades:</strong> Permanent improvements that boost your production or unlock new game mechanics. They are purchased from the "Upgrades" screen.</p>
-				<p><strong>The Coop:</strong> The screen where you can purchase different types of specialized chickens. Each chicken provides a unique bonus, such as increasing EPS, finding Golden Feathers, or generating Reputation.</p>
+				<p><strong>The Coop:</strong> The screen where you can purchase different types of specialized chickens. Each chicken provides a unique bonus. Some boost your direct production, while others, like the <strong>Rooster</strong> and <strong>Wyandotte Warrior</strong>, have powerful effects that increase the amount of Reputation you gain when you prestige.</p>
 				<p><strong>Prestige ("Sell the Coop"):</strong> A core mechanic in idle games. When you can afford the cost, you can reset your progress (eggs, upgrades, chickens) for Reputation points. The cost starts at 1 Trillion eggs and doubles with each prestige.</p>
 				<p><strong>Golden Chicken:</strong> A special chicken that randomly appears on the screen. Clicking it awards a large egg bonus equal to 100 times your click power or 10 minutes of your EPS (whichever is greater), further boosted by the "Golden Compass" upgrade.</p>
-				<p><strong>Colored Eggs:</strong> Rare, colored eggs that spawn randomly on the screen. Clicking one grants a powerful but temporary boost (a "buff"), such as making clicks stronger, discounting upgrades, or increasing the chance of finding Golden Feathers.</p>
+				<p><strong>Colored Eggs:</strong> Rare, colored eggs that spawn randomly on the screen. Clicking one grants a powerful but temporary boost (a "buff"), such as making clicks stronger, discounting upgrades, or increasing the chance of finding Golden Feathers. You can see all your active buffs and their remaining time in the banner that appears at the bottom of the main screen.</p>
 				<p><strong>Achievements:</strong> Milestones unlocked by reaching specific goals. Each unlocked achievement provides a small, permanent, and additive bonus to all egg production.</p>
 				<p><strong>Buff:</strong> A temporary positive effect on your game, usually granted by clicking a Colored Egg.</p>
 				<p><strong>Hard Reset:</strong> An option in the settings menu to completely and permanently erase all your save data and start the game over from the very beginning.</p>


### PR DESCRIPTION
Updates the in-game "How to Play" guide to provide more detailed and accurate descriptions of game mechanics that were recently fixed or implemented.

- The "Coop" section now explicitly mentions the role of Roosters and Wyandotte Warriors in the prestige system.
- The "Colored Eggs" section now informs the player about the new UI banner that tracks active buffs.